### PR TITLE
fix option dialog

### DIFF
--- a/addon/chrome/content/preferences/checkbox_tmp-ce.js
+++ b/addon/chrome/content/preferences/checkbox_tmp-ce.js
@@ -10,9 +10,10 @@
     }
 
     connectedCallback() {
-      if (this.delayConnectedCallback()) {
+      if (this._initialized) {
         return;
       }
+      
       this.textContent = "";
       this.appendChild(MozXULElement.parseXULToFragment(`
       <checkbox class="checkbox" ></checkbox>
@@ -26,6 +27,8 @@
       // XXX: Implement `this.inheritAttribute()` for the [inherits] attribute in the markup above!
 
       this._checkbox = this.getElementsByClassName("checkbox")[0];
+    
+      this._initialized = true;
     }
 
     set label(val) {

--- a/addon/chrome/content/preferences/links.js
+++ b/addon/chrome/content/preferences/links.js
@@ -6,6 +6,24 @@ var gLinksPane = {
     this.singleWindow($("singleWindow").checked);
     this.externalLinkValue($("externalLink").checked);
 
+    $("externalLinkTarget").querySelector('menuitem[value="-1"]').label = $("externalLinkTarget").querySelector('menuitem[value="3"]').label;
+    const config = { attributes: true };
+    const callback = function (mutationList) {
+      for (const mutation of mutationList) {
+        if (mutation.type === 'attributes' && mutation.attributeName == "label") {
+          try {
+            if (mutation.target.hasAttribute("label")) {
+              $("externalLinkTarget").querySelector('menuitem[value="-1"]').label = mutation.target.label;
+            }
+          } catch (ex) {
+            Cu.reportError(ex);
+          }
+        }
+      }
+    };
+    const observer = new MutationObserver(callback);
+    observer.observe($("generalWindowOpen"), config);
+
     gPrefWindow.setDisabled("obs_opentabforAllLinks", $("pref_opentabforLinks").value == 1);
 
     gPrefWindow.initPane("paneLinks");
@@ -16,9 +34,10 @@ var gLinksPane = {
     let preference = $(external.getAttribute("preference"));
     if (!checked)
       preference.value = -1;
-    else if (preference.valueFromPreferences == -1)
+    else if (preference.value == -1) {
+      external.value = $("generalWindowOpen").value;
       preference.value = $("generalWindowOpen").value;
-
+    }
     external.firstChild.firstChild.hidden = checked;
     gPrefWindow.setDisabled("obs_externalLink", !checked);
   },


### PR DESCRIPTION
This should fix follow problems:
> 3\. Some preferences are missing label or value when the preference window open:
> * Some preferences disable state dependent on other preferences, many are not correct after window load or when the controlling preference change state (checkbox clicked)
> * Links pane - 2nd menulist (id="divertedWindowOpen") is missing a label
> * Links pane - button (id="advancedSetting") should be disabled when checkbox (id="filetypeEnable") is not checked.
> * Links pane - Radiogroup (id="opentabforLinks)" is missing a value (one of the radio should be selected), both radio elements should be disabled when checkbox (id="forceLinkToTab") is not checked.


> 6\. error when clicking on checkbox
> 
> ```
>    get checked chrome://tabmixplus/content/preferences/checkbox_tmp-ce.js:52
>    updateExternalLinkCheckBox chrome://tabmixplus/content/preferences/links.js:32
>    anonymous chrome://tabmixplus/content/preferences/prefs-ce.js line 432 > Function:3
>    setElementValue chrome://tabmixplus/content/preferences/prefs-ce.js:434
>    updateElements chrome://tabmixplus/content/preferences/prefs-ce.js:540
>    connectedCallback chrome://tabmixplus/content/preferences/prefs-ce.js:159
>    connectedCallback chrome://tabmixplus/content/prefe
> rences/prefs-ce.js:622
> ```

These problems actually have a common source thus have to be fix together.


