### PR TITLE
rename tab panel fix

### DIFF
--- a/addon/chrome/content/overlay/browser.css
+++ b/addon/chrome/content/overlay/browser.css
@@ -234,6 +234,7 @@ so display: none !important; does not hide the button */
 .tab-progress {
   margin: 0;
   min-width: 0;
+  width: 0;
 }
 
 .tabbrowser-tab > .tab-stack > .tab-progress-container {

--- a/addon/chrome/content/overlay/renameTab.xhtml
+++ b/addon/chrome/content/overlay/renameTab.xhtml
@@ -33,23 +33,15 @@
       </vbox>
      </row>
     <spacer/>
-    <grid flex="1">
-      <columns>
-        <column/>
-        <column flex="1"/>
-      </columns>
-      <rows>
-        <row align="center">
-          <label control="tabmixRenametab_titleField" value="&title.label;:"/>
-          <html:input id="tabmixRenametab_titleField" oninput="Tabmix.renameTab.onNewTitle(this.value);"/>
-        </row>
-        <row align="center" id="tabmixRenametab_defaultRow">
-          <label control="tabmixRenametab_defaultField" value="&default.label;:"/>
-          <html:input id="tabmixRenametab_defaultField"
-                   readonly="true" plain="true"/>
-        </row>
-      </rows>
-    </grid>
+    <vbox flex="1">
+      <label control="tabmixRenametab_titleField" value="&title.label;:"/>
+      <html:input id="tabmixRenametab_titleField" oninput="Tabmix.renameTab.onNewTitle(this.value);"/>
+      <vbox id="tabmixRenametab_defaultRow">
+        <label control="tabmixRenametab_defaultField" value="&default.label;:"/>
+        <html:input id="tabmixRenametab_defaultField"
+                  readonly="true" plain="true"/>
+      </vbox>
+    </vbox>
     <spacer/>
     <checkbox id="tabmixRenametab_checkbox" label="&renametab.permanently.label;"
               align="center" checked="true"
@@ -59,7 +51,6 @@
     <hbox id="tabmixRenametab_buttons" pack="end">
       <button id="tabmixRenametab_doneButton"
               class="editBookmarkPanelBottomButton"
-              data-l10n-id="bookmark-panel-done-button"
               default="true"
               oncommand="Tabmix.renameTab.update();"/>
       <button id="tabmixRenametab_deleteButton"

--- a/addon/chrome/content/overlay/renameTab.xhtml
+++ b/addon/chrome/content/overlay/renameTab.xhtml
@@ -10,7 +10,8 @@
 ]>
 
 <overlay id="renameTabOverlay"
-         xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+         xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+         xmlns:html="http://www.w3.org/1999/xhtml">
 
   <panel id="tabmixRenametab_panel"
          onpopupshown="Tabmix.renameTab.onpopupshown(event);"
@@ -40,11 +41,11 @@
       <rows>
         <row align="center">
           <label control="tabmixRenametab_titleField" value="&title.label;:"/>
-          <textbox id="tabmixRenametab_titleField" oninput="Tabmix.renameTab.onNewTitle(this.value);"/>
+          <html:input id="tabmixRenametab_titleField" oninput="Tabmix.renameTab.onNewTitle(this.value);"/>
         </row>
         <row align="center" id="tabmixRenametab_defaultRow">
           <label control="tabmixRenametab_defaultField" value="&default.label;:"/>
-          <textbox id="tabmixRenametab_defaultField"
+          <html:input id="tabmixRenametab_defaultField"
                    readonly="true" plain="true"/>
         </row>
       </rows>
@@ -58,7 +59,7 @@
     <hbox id="tabmixRenametab_buttons" pack="end">
       <button id="tabmixRenametab_doneButton"
               class="editBookmarkPanelBottomButton"
-              label="&editBookmark.done.label;"
+              data-l10n-id="bookmark-panel-done-button"
               default="true"
               oncommand="Tabmix.renameTab.update();"/>
       <button id="tabmixRenametab_deleteButton"

--- a/addon/chrome/content/places/places.js
+++ b/addon/chrome/content/places/places.js
@@ -409,14 +409,14 @@ var TMP_Places = {
     }
     return this.asyncGetTabTitle(tab, url).then(newTitle => {
       // only call setTabTitle if we found one to avoid loop
-      if (newTitle && newTitle != tab.label) {
+      if (!newTitle) return false;
+      if (newTitle != tab.label) {
         this.setTabTitle(tab, url, newTitle);
         if (initial) {
           tab._labelIsInitialTitle = true;
         }
-        return true;
       }
-      return false;
+      return true;
     });
   },
 

--- a/addon/modules/RenameTab.jsm
+++ b/addon/modules/RenameTab.jsm
@@ -6,6 +6,8 @@ const Cu = Components.utils;
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm", this);
 Cu.import("chrome://tabmix-resource/content/TabmixSvc.jsm", this);
+Cu.import("chrome://tabmix-resource/content/bootstrap/ChromeManifest.jsm");
+Cu.import("chrome://tabmix-resource/content/bootstrap/Overlays.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "TabmixPlacesUtils",
   "chrome://tabmix-resource/content/Places.jsm");
@@ -60,13 +62,14 @@ this.RenameTab = {
       return;
     }
 
-    popup = this.panel = this.window.document.createElement("panel");
+    popup = this.panel = this.window.document.createXULElement("panel");
     popup._overlayLoaded = false;
     popup.id = "tabmixRenametab_panel";
+    popup.hidden = true; // prevent panel initialize. initialize before overlay break it.
     this._element("mainPopupSet").appendChild(popup);
-    this.window.document.loadOverlay(
-      "chrome://tabmixplus/content/overlay/renameTab.xul", this
-    );
+    const ov = new Overlays(new ChromeManifest(), this.window);
+    ov.load("chrome://tabmixplus/content/overlay/renameTab.xhtml");
+    this.observe(null,"xul-overlay-merged");
   },
 
   observe(aSubject, aTopic) {
@@ -129,12 +132,12 @@ this.RenameTab = {
     var tab = data.tab;
     var label = data.value;
     var resetDefault = aReset || (label == data.docTitle && !data.permanently);
-    var url = resetDefault ? null : data.permanently ? "*" : data.url;
+    var url = resetDefault ? '' : data.permanently ? "*" : data.url;
 
     var win = this.window;
-    win.Tabmix.setItem(tab, "fixed-label", resetDefault ? null : label);
+    win.Tabmix.setItem(tab, "fixed-label", resetDefault ? '' : label);
     win.Tabmix.setItem(tab, "label-uri", url);
-    TabmixSvc.ss.setCustomTabValue(tab, "fixed-label", resetDefault ? null : label);
+    TabmixSvc.ss.setCustomTabValue(tab, "fixed-label", resetDefault ? '' : label);
     TabmixSvc.ss.setCustomTabValue(tab, "label-uri", url);
     win.TabmixSessionManager.updateTabProp(tab);
 

--- a/addon/modules/RenameTab.jsm
+++ b/addon/modules/RenameTab.jsm
@@ -132,12 +132,12 @@ this.RenameTab = {
     var tab = data.tab;
     var label = data.value;
     var resetDefault = aReset || (label == data.docTitle && !data.permanently);
-    var url = resetDefault ? '' : data.permanently ? "*" : data.url;
+    var url = resetDefault ? null : data.permanently ? "*" : data.url;
 
     var win = this.window;
-    win.Tabmix.setItem(tab, "fixed-label", resetDefault ? '' : label);
+    win.Tabmix.setItem(tab, "fixed-label", resetDefault ? null : label);
     win.Tabmix.setItem(tab, "label-uri", url);
-    TabmixSvc.ss.setCustomTabValue(tab, "fixed-label", resetDefault ? '' : label);
+    TabmixSvc.ss.setCustomTabValue(tab, "fixed-label", resetDefault ? null : label);
     TabmixSvc.ss.setCustomTabValue(tab, "label-uri", url);
     win.TabmixSessionManager.updateTabProp(tab);
 

--- a/addon/modules/RenameTab.jsm
+++ b/addon/modules/RenameTab.jsm
@@ -69,7 +69,7 @@ this.RenameTab = {
     this._element("mainPopupSet").appendChild(popup);
     const ov = new Overlays(new ChromeManifest(), this.window);
     ov.load("chrome://tabmixplus/content/overlay/renameTab.xhtml");
-    this.observe(null,"xul-overlay-merged");
+    this.observe(null, "xul-overlay-merged");
   },
 
   observe(aSubject, aTopic) {
@@ -79,6 +79,8 @@ this.RenameTab = {
     this.panel._overlayLoaded = true;
     this.panel.hidden = false;
 
+    const l10Id = TabmixSvc.version(890) ? "bookmark-panel-save-button" : "bookmark-panel-done-button";
+    this._element("tabmixRenametab_doneButton").setAttribute("data-l10n-id", l10Id);
     this._element("tabmixRenametab_deleteButton").label = TabmixSvc.getDialogStrings("Cancel");
 
     // reorder buttons for MacOS & Linux


### PR DESCRIPTION
I got panel working.
But there is something in the callback hell of the set tab title would toggle the tittle between custom and original for every other reload of the page(f5, reload button) and load from url bar would loop it back to where it was(it still changes tittle you can see text is changing). Initial(restore session at browser startup) load would apply the user set tittle correctly so far. 

I just can't figure out how to solve it now.

See:https://github.com/onemen/TabMixPlus/issues/39#issuecomment-816686051
&:https://github.com/onemen/TabMixPlus/issues/39#issuecomment-816699691
