### PR TITLE
Load overlay only for selected PrefPane

### DIFF
--- a/addon/chrome/content/overlay/multirow.css
+++ b/addon/chrome/content/overlay/multirow.css
@@ -20,10 +20,6 @@
   padding-inline-start: 0px;
 }
 
-#tabbrowser-arrowscrollbox[flowing=multibar][orient=horizontal] {
-  overflow: -moz-hidden-unscrollable;
-  display: block;
-}
 
 .tabbrowser-tab {
   height: var(--tab-min-height_mlt);

--- a/addon/chrome/content/preferences/mouse.xhtml
+++ b/addon/chrome/content/preferences/mouse.xhtml
@@ -119,8 +119,8 @@
               <tab label="&shift.label;"  linkedpanel="pl" class="subtabs"/>
               <tab label="&alt.label;"    linkedpanel="pl" class="subtabs"/>
             </tabs>
-            <tabpanels class="groupbox-panels" flex="0" selectedIndex="1"
-                  onselect="if(event.target.selectedIndex == 1) event.stopPropagation(); this.selectedIndex = 0;">
+            <tabpanels class="groupbox-panels" flex="0" selectedIndex="0"
+                  onselect="if (this.tabbox &amp;&amp; this.selectedIndex !== 0) {event.stopPropagation(); this.selectedIndex = 0;}">
               <tabpanel id="_tabpanel">
                 <spacer style="height: 8px;"/>
                 <!-- click on a tab -->

--- a/addon/chrome/content/preferences/prefs-ce.js
+++ b/addon/chrome/content/preferences/prefs-ce.js
@@ -8,11 +8,12 @@ const {Overlays} = ChromeUtils.import("chrome://tabmix-resource/content/bootstra
 
 // delay connectedCallback() of tabs till tabs inserted into DOM so it won't be run multiple times and cause trouble.
 let delayTabsConnectedCallback = false;
-customElements.get('tabs').prototype.delayConnectedCallback = function() {
+const MozTabs = customElements.get("tabs").prototype;
+MozTabs.delayConnectedCallback = function() {
   return delayTabsConnectedCallback;
 };
 
-Object.defineProperty(customElements.get("tab").prototype, "container", {
+Object.defineProperty(MozTabs, "container", {
   get() {
     return this.parentNode;
   }
@@ -1574,7 +1575,7 @@ class PrefWindow extends MozXULElement {
       aPaneElement.connectedCallback();
       // now we can safely call connectedCallback for all tabs in this PrefPane
       delayTabsConnectedCallback = false;
-      aPaneElement.querySelectorAll("tabs").forEach(tab => tab.connectedCallback());
+      aPaneElement.querySelectorAll("tabs").forEach(tabs => tabs.connectedCallback());
 
       this._fireEvent("paneload", aPaneElement);
       this._selectPane(aPaneElement);

--- a/addon/chrome/content/preferences/prefs-ce.js
+++ b/addon/chrome/content/preferences/prefs-ce.js
@@ -612,21 +612,11 @@ class PrefPane extends MozXULElement {
       return;
     }
 
-    delayTabsConnectedCallback = true;
-    if (this.src) {
-      const ov = new Overlays(new ChromeManifest(), window.document.defaultView);
-      ov.load(this.src);
-    }
-
     const fragment = this.fragment;
     const contentBox = fragment.querySelector('.content-box');
     const childNodes = [...this.childNodes];
     this.appendChild(fragment);
     contentBox.append(...childNodes);
-
-    // now we can safly call connectedCallback on all tabs in this PrefPane
-    delayTabsConnectedCallback = false;
-    this.querySelectorAll("tabs").forEach(tab => tab.connectedCallback());
 
     this.initializeAttributeInheritance();
 
@@ -1570,8 +1560,18 @@ class PrefWindow extends MozXULElement {
 
     this._selector.selectedItem = document.getElementsByAttribute("pane", aPaneElement.id)[0];
     if (!aPaneElement.loaded) {
+      delayTabsConnectedCallback = true;
+      const src = aPaneElement.src;
+      if (src) {
+        const ov = new Overlays(new ChromeManifest(), window.document.defaultView);
+        ov.load(src);
+      }
       aPaneElement.loaded = true;
       aPaneElement.connectedCallback();
+      // now we can safely call connectedCallback for all tabs in this PrefPane
+      delayTabsConnectedCallback = false;
+      aPaneElement.querySelectorAll("tabs").forEach(tab => tab.connectedCallback());
+
       this._fireEvent("paneload", aPaneElement);
       this._selectPane(aPaneElement);
     } else

--- a/addon/chrome/content/preferences/prefs-ce.js
+++ b/addon/chrome/content/preferences/prefs-ce.js
@@ -1084,7 +1084,7 @@ class PrefWindow extends MozXULElement {
     fragmentLastChild.append(...otherChildren);
 
     updateAttribute("dlgbuttons", "accept,cancel");
-    updateAttribute("persist", "lastSelected screenX screenY");
+    updateAttribute("persist", "screenX screenY");
     updateAttribute("closebuttonlabel", MozXULElement.parseXULToFragment(`<div attr="&uiTour.infoPanel.close;" />`, ["chrome://browser/locale/browser.dtd"]).childNodes[0].attributes[0].value);
     updateAttribute("closebuttonaccesskey", "C");
     updateAttribute("role", "dialog");
@@ -1499,13 +1499,17 @@ class PrefWindow extends MozXULElement {
   }
 
   get lastSelected() {
+    if (!this.hasAttribute("lastSelected")) {
+      const val = Services.xulStore.getValue(this, "persist", "lastSelected");
+      this.setAttribute('lastSelected', val);
+      return val;
+    }
     return this.getAttribute('lastSelected');
   }
 
   set lastSelected(val) {
     this.setAttribute("lastSelected", val);
-    const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
-    Services.xulStore.persist(this, "lastSelected");
+    Services.xulStore.setValue(this, "persist", "lastSelected", val);
     return val;
   }
 

--- a/addon/chrome/content/tab/tab.js
+++ b/addon/chrome/content/tab/tab.js
@@ -1699,8 +1699,13 @@ gTMPprefObserver = {
     const protonPrefVal = Services.prefs.getBoolPref("browser.proton.tabs.enabled", false);
     let newRule;
     if (!Tabmix.isVersion(880)) {
-      // tabmix-tabs-closebutton toolbarbutton
-      document.getElementById("tabmix-tabs-closebutton").setAttribute("tabmix-fill-opacity", true);
+      // the button is not ready when we call dynamicProtonRules early
+      // onContentLoaded>addDynamicRules>dynamicProtonRules
+      setTimeout(() => {
+        // tabmix-tabs-closebutton toolbarbutton
+        document.getElementById("tabmix-tabs-closebutton").setAttribute("tabmix-fill-opacity", true);
+      }, 100);
+
       newRule = `#tabmix-tabs-closebutton[tabmix-fill-opacity] > .toolbarbutton-icon {
         padding: ${protonPrefVal ? 7.4 : 4}px 4px !important;
       }`;

--- a/addon/chrome/skin/preferences.css
+++ b/addon/chrome/skin/preferences.css
@@ -225,7 +225,7 @@ prefpane {
   padding: 3px 1px 1px 1px;
 }
 
-prefpane > tabbox {
+prefpane > .content-box > tabbox {
   width: 525px;
   height: 464px;
 }

--- a/addon/chrome/skin/preferences.css
+++ b/addon/chrome/skin/preferences.css
@@ -256,7 +256,7 @@ tabbox > tabpanels {
 }
 
 /* for Mac */
-#TabMIxPreferences[mac] prefpane > tabbox {
+#TabMIxPreferences[mac] prefpane > .content-box > tabbox {
   height: 468px;
 }
 


### PR DESCRIPTION
With the code from ```preferences.xml```, when Tabmix options was opened it would only loaded overlay for last selected PrefPan, then on when use switch to different pane it load only the new selected pane

@117649, check this pr an see if you find any issues