### PR TITLE
Make fetchOverlay async

### DIFF
--- a/addon/chrome/content/links/setup.js
+++ b/addon/chrome/content/links/setup.js
@@ -108,7 +108,7 @@ Tabmix.beforeBrowserInitOnLoad = function() {
       Tabmix.prepareLoadOnStartup = function() { };
     }
 
-    if (gBrowserInit.tabmix_delayedStartupStarted) {
+    if (Tabmix.isAfterMozAfterPaint) {
       Tabmix.beforeDelayedStartup();
     } else {
       window.addEventListener("MozAfterPaint", Tabmix.beforeDelayedStartup, {once: true});

--- a/addon/chrome/content/links/userInterface.js
+++ b/addon/chrome/content/links/userInterface.js
@@ -272,21 +272,6 @@ Tabmix.checkCurrent = function TMP_checkCurrent(url) {
   return "current";
 };
 
-/**
- * @brief copy Tabmix data from old tab to new tab.
- *        we use it before swapBrowsersAndCloseOther
- */
-Tabmix.copyTabData = function TMP_copyTabData(newTab, oldTab) {
-  let _xulAttributes = ["protected", "_locked", "fixed-label", "label-uri", "reload-data", "visited"];
-
-  var self = this;
-  _xulAttributes.forEach(function _setData(attr) {
-    self.setItem(newTab, attr, oldTab.hasAttribute(attr) ? oldTab.getAttribute(attr) : null);
-  });
-
-  this.restoreTabState(newTab);
-};
-
 Tabmix.restoreTabState = function TMP_restoreTabState(aTab) {
   if (aTab.hasAttribute("_locked")) {
     if (aTab.getAttribute("_locked") == "true")

--- a/addon/chrome/content/minit/tablib.js
+++ b/addon/chrome/content/minit/tablib.js
@@ -1589,30 +1589,6 @@ Tabmix.tablib = {
       }
     };
 
-    Tabmix.originalFunctions.swapBrowsersAndCloseOther = gBrowser.swapBrowsersAndCloseOther;
-    let swapTab = function tabmix_swapBrowsersAndCloseOther(aOurTab, aOtherTab) {
-      // Do not allow transferring a private tab to a non-private window
-      // and vice versa.
-      if (PrivateBrowsingUtils.isWindowPrivate(window) !=
-          PrivateBrowsingUtils.isWindowPrivate(aOtherTab.ownerGlobal)) {
-        return false;
-      }
-
-      if (gBrowserInit.tabmix_delayedStartupStarted && !gBrowserInit.delayedStartupFinished) {
-        // we probably will never get here in single window mode
-        if (Tabmix.singleWindowMode) {
-          return false;
-        }
-        Tabmix._afterTabduplicated = true;
-        let url = aOtherTab.linkedBrowser.currentURI.spec;
-        gBrowser.tabContainer._updateCloseButtons(true, url);
-      }
-
-      Tabmix.copyTabData(aOurTab, aOtherTab);
-      return Tabmix.originalFunctions.swapBrowsersAndCloseOther.apply(this, arguments);
-    };
-    Tabmix.setNewFunction(gBrowser, "swapBrowsersAndCloseOther", swapTab);
-
     // Bug 752376 - Avoid calling scrollbox.ensureElementIsVisible()
     // if the tab strip doesn't overflow to prevent layout flushes
     gBrowser.ensureTabIsVisible = function tabmix_ensureTabIsVisible(aTab, aSmoothScroll) {

--- a/addon/chrome/content/preferences/prefs-ce.js
+++ b/addon/chrome/content/preferences/prefs-ce.js
@@ -1580,18 +1580,23 @@ class PrefWindow extends MozXULElement {
       const src = aPaneElement.src;
       if (src) {
         const ov = new Overlays(new ChromeManifest(), window.document.defaultView);
-        ov.load(src);
+        ov.load(src).then(() => this._paneLoaded(aPaneElement));
+      } else {
+        this._paneLoaded(aPaneElement);
       }
-      aPaneElement.loaded = true;
-      aPaneElement.connectedCallback();
-      // now we can safely call connectedCallback for all tabs in this PrefPane
-      delayTabsConnectedCallback = false;
-      aPaneElement.querySelectorAll("tabs").forEach(tabs => tabs.connectedCallback());
-
-      this._fireEvent("paneload", aPaneElement);
-      this._selectPane(aPaneElement);
     } else
       this._selectPane(aPaneElement);
+  }
+
+  _paneLoaded(aPaneElement) {
+    aPaneElement.loaded = true;
+    aPaneElement.connectedCallback();
+    // now we can safely call connectedCallback for all tabs in this PrefPane
+    delayTabsConnectedCallback = false;
+    aPaneElement.querySelectorAll("tabs").forEach(tabs => tabs.connectedCallback());
+
+    this._fireEvent("paneload", aPaneElement);
+    this._selectPane(aPaneElement);
   }
 
   _fireEvent(aEventName, aTarget) {

--- a/addon/chrome/content/tab/tab.js
+++ b/addon/chrome/content/tab/tab.js
@@ -411,7 +411,7 @@ Tabmix.tabsUtils = {
     }
     this.initialized = true;
 
-    const tab = this.tabBar.allTabs[0];
+    const tab = gBrowser.selectedTab;
 
     Tabmix.rtl = RTL_UI;
     Tabmix.ltr = !RTL_UI;

--- a/addon/chrome/content/tab/tabsBindings.js
+++ b/addon/chrome/content/tab/tabsBindings.js
@@ -1,11 +1,6 @@
 "use strict";
 
 (function() {
-  // with bootstrap.js we get here after DOMContentLoaded was fired
-  // we can call our initializer with 'onContentLoaded' flag
-  Tabmix.initialization.init.initialized = false;
-  Tabmix.initialization.run("onContentLoaded", gBrowser.tabContainer);
-
   Tabmix.setNewFunction(gBrowser.tabContainer, "_notifyBackgroundTab", function _notifyBackgroundTab(aTab) {
     if (aTab.pinned || aTab.hidden) {
       return;

--- a/addon/chrome/content/tabmix.js
+++ b/addon/chrome/content/tabmix.js
@@ -209,15 +209,14 @@ Tabmix.afterDelayedStartup = function() {
 
 var TMP_eventListener = {
   init: function TMP_EL_init() {
-    // before-initial-tab-adopted is fired before we are ready,
-    // we have to make sure our initialization finshed before
-    // Firefox call gBrowser.swapBrowsersAndCloseOther
-    window.addEventListener("before-initial-tab-adopted", () => {
-      Tabmix.initialization.run("onWindowOpen");
-    }, {capture: true, once: true});
-
     window.addEventListener("load", this);
+
     window.addEventListener("SSWindowRestored", this);
+    if (Tabmix.isAfterSSWindowRestored) {
+      delete Tabmix.isAfterSSWindowRestored;
+      this.onSSWindowRestored();
+    }
+
     window.delayedStartupPromise.then(() => {
       Tabmix.initialization.run("afterDelayedStartup");
     });
@@ -1094,7 +1093,6 @@ Tabmix.initialization = {
       *       when ImTranslator extension installed)
       */
     let stopInitialization = false;
-    Tabmix.singleWindowMode = Tabmix.prefs.getBoolPref("singleWindow");
     if (Tabmix.singleWindowMode) {
       const tmp = ChromeUtils.import("chrome://tabmix-resource/content/SingleWindowModeUtils.jsm");
       stopInitialization = tmp.SingleWindowModeUtils.newWindow(window);
@@ -1160,5 +1158,3 @@ Tabmix._deferredInitialized = (function() {
 
   return deferred;
 }());
-
-TMP_eventListener.init();

--- a/addon/chrome/content/tabmix.xhtml
+++ b/addon/chrome/content/tabmix.xhtml
@@ -18,9 +18,6 @@
          xmlns:html="http://www.w3.org/1999/xhtml"
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-   <script type="application/javascript" src="chrome://tabmixplus/content/broadcaster.js"/>
-
-   <script type="application/javascript" src="chrome://tabmixplus/content/utils.js"/>
    <script type="application/javascript" src="chrome://tabmixplus/content/tab/scrollbox.js"/>
    <script type="application/javascript" src="chrome://tabmixplus/content/tab/tabBindings.js"/>
    <script type="application/javascript" src="chrome://tabmixplus/content/tabmix.js"/>
@@ -37,6 +34,14 @@
    <script type="application/javascript" src="chrome://tabmixplus/content/session/sessionStore.js"/>
    <script type="application/javascript" src="chrome://tabmixplus/content/extensions/extensions.js"/>
    <script type="application/javascript" src="chrome://tabmixplus/content/tab/tabsBindings.js"/>
+
+  <script type="text/javascript">
+    // with bootstrap.js we get here after DOMContentLoaded was fired
+    // we can call our initializer with 'onContentLoaded' flag
+    Tabmix.initialization.init.initialized = false;
+    TMP_eventListener.init();
+    Tabmix.initialization.run("onContentLoaded", gBrowser.tabContainer);
+  </script>
 
   <commandset id="mainCommandSet">
     <command id="TabmixSessionUtils:SaveThisWindow" observes="tmp_disableSave"

--- a/addon/modules/RenameTab.jsm
+++ b/addon/modules/RenameTab.jsm
@@ -65,8 +65,9 @@ this.RenameTab = {
     popup.hidden = true; // prevent panel initialize. initialize before overlay break it.
     this._element("mainPopupSet").appendChild(popup);
     const ov = new Overlays(new ChromeManifest(), this.window);
-    ov.load("chrome://tabmixplus/content/overlay/renameTab.xhtml");
-    this.observe(null, "xul-overlay-merged");
+    ov.load("chrome://tabmixplus/content/overlay/renameTab.xhtml").then(() => {
+      this.observe(null, "xul-overlay-merged");
+    });
   },
 
   observe(aSubject, aTopic) {

--- a/addon/modules/bootstrap/Overlays.jsm
+++ b/addon/modules/bootstrap/Overlays.jsm
@@ -161,6 +161,12 @@ class Overlays {
       forwardReferences.unshift(...t_forwardReferences);
     }
 
+    // We've resolved all the forward references we can, we can now go ahead and load the scripts
+    this.deferredLoad = [];
+    for (const script of this.unloadedScripts) {
+      this.deferredLoad.push(...this.loadScript(script));
+    }
+
     const ids = xulStore.getIDsEnumerator(this.location);
     while (ids.hasMore()) {
       this.persistedIDs.add(ids.getNext());
@@ -216,11 +222,6 @@ class Overlays {
       }
     }
 
-    // We've resolved all the forward references we can, we can now go ahead and load the scripts
-    this.deferredLoad = [];
-    for (const script of this.unloadedScripts) {
-      this.deferredLoad.push(...this.loadScript(script));
-    }
     if (this.document.readyState == "complete") {
       setTimeout(() => {
         this._finish();

--- a/addon/modules/bootstrap/Overlays.jsm
+++ b/addon/modules/bootstrap/Overlays.jsm
@@ -161,12 +161,6 @@ class Overlays {
       forwardReferences.unshift(...t_forwardReferences);
     }
 
-    // We've resolved all the forward references we can, we can now go ahead and load the scripts
-    this.deferredLoad = [];
-    for (const script of this.unloadedScripts) {
-      this.deferredLoad.push(...this.loadScript(script));
-    }
-
     const ids = xulStore.getIDsEnumerator(this.location);
     while (ids.hasMore()) {
       this.persistedIDs.add(ids.getNext());
@@ -222,6 +216,11 @@ class Overlays {
       }
     }
 
+    // We've resolved all the forward references we can, we can now go ahead and load the scripts
+    this.deferredLoad = [];
+    for (const script of this.unloadedScripts) {
+      this.deferredLoad.push(...this.loadScript(script));
+    }
     if (this.document.readyState == "complete") {
       setTimeout(() => {
         this._finish();

--- a/addon/modules/bootstrap/ScriptsLoader.jsm
+++ b/addon/modules/bootstrap/ScriptsLoader.jsm
@@ -1,0 +1,122 @@
+/**
+ * Load Tabmix scripts to navigator:browser window.
+ */
+
+"use strict";
+
+this.EXPORTED_SYMBOLS = ["ScriptsLoader"];
+
+const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const {XPCOMUtils} = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+  //
+  PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.jsm",
+});
+
+const initialized = new WeakSet();
+
+this.ScriptsLoader = {
+  initForWindow(window, promiseOverlayLoaded) {
+    if (initialized.has(window)) {
+      return;
+    }
+    initialized.add(window);
+
+    this._loadScripts(window, promiseOverlayLoaded);
+    this._addListeners(window);
+  },
+
+  _loadScripts(window, promiseOverlayLoaded) {
+    Services.scriptloader.loadSubScript("chrome://tabmixplus/content/broadcaster.js", window);
+    Services.scriptloader.loadSubScript("chrome://tabmixplus/content/utils.js", window);
+
+    window.Tabmix.promiseOverlayLoaded = promiseOverlayLoaded;
+  },
+
+  _addListeners(window) {
+    const {Tabmix} = window;
+
+    window.addEventListener(
+      "MozAfterPaint",
+      () => {
+        Tabmix.isAfterMozAfterPaint = true;
+      },
+      {once: true}
+    );
+
+    window.addEventListener(
+      "SSWindowRestored",
+      () => {
+        Tabmix.isAfterSSWindowRestored = true;
+      },
+      {once: true}
+    );
+
+    // before-initial-tab-adopted is fired before we are ready,
+    // we have to make sure our initialization finshed before
+    // Firefox call gBrowser.swapBrowsersAndCloseOther
+    window.addEventListener(
+      "before-initial-tab-adopted",
+      () => {
+        this._prepareBeforeOverlays(window);
+      },
+      {capture: true, once: true}
+    );
+  },
+
+  /**
+   * initialize functions that can be called by events that fired before
+   * our overlay is ready.
+   *
+   * @param window
+   */
+  _prepareBeforeOverlays(window) {
+    const {gBrowser, gBrowserInit, Tabmix} = window;
+
+    Tabmix.singleWindowMode = Tabmix.prefs.getBoolPref("singleWindow");
+    /**
+     * @brief copy Tabmix data from old tab to new tab.
+     *        we use it before swapBrowsersAndCloseOther
+     */
+    Tabmix.copyTabData = function TMP_copyTabData(newTab, oldTab) {
+      /* prettier-ignore */
+      const _xulAttributes = ["protected", "_locked", "fixed-label", "label-uri", "reload-data", "visited"];
+
+      _xulAttributes.forEach(attr => {
+        this.setItem(newTab, attr, oldTab.hasAttribute(attr) ? oldTab.getAttribute(attr) : null);
+      });
+
+      this.promiseOverlayLoaded.then(() => {
+        this.restoreTabState(newTab);
+        window.TMP_Places.asyncSetTabTitle(newTab);
+      });
+    };
+
+    Tabmix.originalFunctions.swapBrowsersAndCloseOther = gBrowser.swapBrowsersAndCloseOther;
+    const swapTab = function tabmix_swapBrowsersAndCloseOther(aOurTab, aOtherTab) {
+      // Do not allow transferring a private tab to a non-private window
+      // and vice versa.
+      if (
+        PrivateBrowsingUtils.isWindowPrivate(window) !==
+        PrivateBrowsingUtils.isWindowPrivate(aOtherTab.ownerGlobal)
+      ) {
+        return false;
+      }
+
+      if (Tabmix.isAfterMozAfterPaint && !gBrowserInit.delayedStartupFinished) {
+        // we probably will never get here in single window mode
+        if (Tabmix.singleWindowMode) {
+          return false;
+        }
+        Tabmix._afterTabduplicated = true;
+        const url = aOtherTab.linkedBrowser.currentURI.spec;
+        gBrowser.tabContainer._updateCloseButtons(true, url);
+      }
+
+      Tabmix.copyTabData(aOurTab, aOtherTab);
+      return Tabmix.originalFunctions.swapBrowsersAndCloseOther.apply(this, arguments);
+    };
+    Tabmix.setNewFunction(gBrowser, "swapBrowsersAndCloseOther", swapTab);
+  },
+};


### PR DESCRIPTION
@117649,  @xiaoxiaoflood,
Making fetchOverlay async fixes #109.

This also prevent some warning in the console:
```
Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user’s experience.
For more help http://xhr.spec.whatwg.org/
```
In [http://xhr.spec.whatwg.org](http://xhr.spec.whatwg.org) is says:
`Developers must not pass false for the async argument when current global object is a Window object`.
