### PR TITLE
fix: Waterfox G5 break Multi-row tabs

### DIFF
--- a/addon/chrome/content/overlay/browser.css
+++ b/addon/chrome/content/overlay/browser.css
@@ -269,6 +269,9 @@ so display: none !important; does not hide the button */
 #TabsToolbar #tabbrowser-tabs:not([overflow="true"], [hashiddentabs], [showalltabsbutton]) ~ #alltabs-button {
   display: none;
 }
+#TabsToolbar #tabbrowser-tabs[showalltabsbutton] ~ #alltabs-button {
+  display: -moz-box;
+}
 #TabsToolbar #tabbrowser-tabs:not([overflow="true"], [showalltabsbutton])[using-closing-tabs-spacer] ~ #alltabs-button {
   /* temporary space to keep a tab's close button under the cursor */
   display: -moz-box;

--- a/addon/chrome/content/overlay/multirow.css
+++ b/addon/chrome/content/overlay/multirow.css
@@ -54,6 +54,12 @@
   max-height: calc(var(--tab-min-height_mlt) * var(--tabs-lines));
 }
 
+/* waterfox with userChrome enabled set overflow: hidden */
+#TabsToolbar[multibar] {
+  height: auto !important;
+  overflow: unset !important;
+}
+
 #tabbrowser-tabs[multibar][orient=horizontal] .tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
   margin-top: -1px;
 }

--- a/addon/chrome/content/tab/tab.js
+++ b/addon/chrome/content/tab/tab.js
@@ -1818,6 +1818,11 @@ gTMPprefObserver = {
       }
     };
 
+    // fix scroll buttons height when Waterfox userChrome enabled
+    const reduceButtonHeight =
+      TabmixSvc.isG5Waterfox && Services.prefs.getBoolPref("userChrome.theme.enable", false);
+    const buttonsMarginBlock = reduceButtonHeight ? "-4px !important" : "0";
+
     insertRule(
       `#tabmix-scrollbox::part(scrollbutton-up),
        #tabmix-scrollbox::part(scrollbutton-down) {
@@ -1825,7 +1830,7 @@ gTMPprefObserver = {
          background-clip: padding-box;
          border: 4px solid transparent;
          border-radius: calc(var(--tab-border-radius) + 4px);
-         margin: 0;
+         margin: ${buttonsMarginBlock};
          padding: calc(var(--toolbarbutton-inner-padding) - 3px) calc(var(--toolbarbutton-inner-padding) - 6px);
        }`
     );

--- a/addon/chrome/skin/tab.css
+++ b/addon/chrome/skin/tab.css
@@ -20,10 +20,6 @@
   max-height: none !important;
 }
 
-#TabsToolbar[multibar] {
-  height: auto !important;
-}
-
 #tabbrowser-tabs[flowing=multibar][multibar=scrollbar] .tabbrowser-tab[collapsed=true] {
   display: none !important;
 }

--- a/addon/modules/TabmixSvc.jsm
+++ b/addon/modules/TabmixSvc.jsm
@@ -396,6 +396,10 @@ XPCOMUtils.defineLazyGetter(TabmixSvc, "isG3Waterfox", () => {
   return Services.appinfo.name == "Waterfox" && isVersion(780);
 });
 
+XPCOMUtils.defineLazyGetter(TabmixSvc, "isG5Waterfox", () => {
+  return Services.appinfo.name == "Waterfox" && isVersion(1020);
+});
+
 XPCOMUtils.defineLazyGetter(TabmixSvc, "isBasilisk", () => {
   return Services.appinfo.name == "Basilisk";
 });


### PR DESCRIPTION
Some minor changes to fix this issue with WaterFox G5 with userChrome.theme.enable with some of the default themes

@117649, can use test this PR

WaterFox provide many userChrome.* if user need more fine tuning 
