### PR TITLE
Update session.xhtml, fix typo

### DIFF
--- a/addon/chrome/content/preferences/session.xhtml
+++ b/addon/chrome/content/preferences/session.xhtml
@@ -83,7 +83,7 @@
       <tabpanels>
         <tabpanel id="sessionsPanel">
           <vbox class="work-in-progress">
-            <label class="bold-label" value="Tabmix Session Manager is not ready yet, use Build in Session Manager" />
+            <label class="bold-label" value="Tabmix Session Manager is not ready yet, use built-in Session Manager" />
           </vbox>
           <html:fieldset align="start">
             <checkbox_tmp id="sessionsOptions" label="&ss.enable.label;"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1147244/235407893-8ebd4cbb-2f29-4557-9b11-6ee2cb78a604.png)

Should read "use built-in Session Manager"